### PR TITLE
Add ability to set a prefix for all log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ A dead simple logger. Will log to STDOUT or STDERR depending on the
 chosen log level. It uses `console.info`, `console.warn` and
 `console.error` and hence supports the same API.
 
-Log levels supported: debug, info, warn, error and fatal (defaults to
-'info').
+Log levels supported: debug, info, warn, error and fatal.
 
 [![build status](https://secure.travis-ci.org/watson/console-log-level.png)](http://travis-ci.org/watson/console-log-level)
 
@@ -26,6 +25,26 @@ log.warn('c');  // will output 'c\n' on STDERR
 log.error('d'); // will output 'd\n' on STDERR
 log.fatal('e'); // will output 'e\n' on STDERR
 ```
+
+## Options
+
+Configure the logger by passing an options object:
+
+```js
+var log = require('console-log-level')({
+  prefix: function () { return new Date().toISOString(); },
+  level: 'info'
+});
+```
+
+### level
+
+A `string` to specify the log level. Defaults to `info`.
+
+### prefix
+
+Specify this option if you want to set a prefix for all log messages.
+This must be a `string` or a `function` that returns a string.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var levels = ['debug', 'info', 'warn', 'error', 'fatal'];
+var util = require('util');
 
 module.exports = function (opts) {
   opts = opts || {};
@@ -15,10 +16,19 @@ module.exports = function (opts) {
   levels.forEach(function (level) {
     logger[level] = function () {
       if (!shouldLog(level)) return;
+
+      var prefix = opts.prefix;
+
       switch (level) {
         case 'debug': level = 'info'; break;
         case 'fatal': level = 'error'; break;
       }
+
+      if (prefix) {
+        if ('function' === typeof prefix) prefix = prefix();
+        arguments[0] = util.format(prefix, arguments[0]);
+      }
+
       console[level].apply(console, arguments);
     };
   });

--- a/test.js
+++ b/test.js
@@ -22,6 +22,18 @@ var restore = function () {
   console.error = origError;
 };
 
+var spyOn = function (method, spy) {
+  console['~' + method] = console[method];
+  console[method] = function () {
+    spy.apply(console, arguments);
+  };
+};
+
+var spyOff = function (method) {
+  console[method] = console['~' + method];
+  delete console['~' + method];
+};
+
 test('log all', function (t) {
   var logger = Logger({ level: 'debug' });
 
@@ -101,4 +113,62 @@ test('set custom level', function (t) {
   restore();
 
   t.end();
+});
+
+test('set prefix', function (t) {
+  var now = new Date().toISOString();
+  var logger = Logger({ prefix: now });
+  var msg = 'bar';
+
+  spyOn('info', function () {
+    spyOff('info');
+    t.equal(arguments[0], now + ' foo %s', 'first arg ok');
+    t.equal(arguments[1], msg, 'second arg ok');
+  });
+
+  spyOn('warn', function () {
+    spyOff('warn');
+    t.equal(arguments[0], now + ' foo %s', 'first arg ok');
+    t.equal(arguments[1], msg, 'second arg ok');
+  });
+
+  spyOn('error', function () {
+    spyOff('error');
+    t.equal(arguments[0], now + ' foo %s', 'first arg ok');
+    t.equal(arguments[1], msg, 'second arg ok');
+    t.end();
+  });
+
+  logger.info('foo %s', msg);
+  logger.warn('foo %s', msg);
+  logger.error('foo %s', msg);
+});
+
+test('set prefix with function', function (t) {
+  var now = new Date().toISOString();
+  var logger = Logger({ prefix: function () { return now; } });
+  var msg = 'bar';
+
+  spyOn('info', function () {
+    spyOff('info');
+    t.equal(arguments[0], now + ' foo %s', 'first arg ok');
+    t.equal(arguments[1], msg, 'second arg ok');
+  });
+
+  spyOn('warn', function () {
+    spyOff('warn');
+    t.equal(arguments[0], now + ' foo %s', 'first arg ok');
+    t.equal(arguments[1], msg, 'second arg ok');
+  });
+
+  spyOn('error', function () {
+    spyOff('error');
+    t.equal(arguments[0], now + ' foo %s', 'first arg ok');
+    t.equal(arguments[1], msg, 'second arg ok');
+    t.end();
+  });
+
+  logger.info('foo %s', msg);
+  logger.warn('foo %s', msg);
+  logger.error('foo %s', msg);
 });


### PR DESCRIPTION
Sometimes it is useful to prefix all log messages with a custom string like a date or a label.
Right now it is possible to do this only by "manually" adding the prefix to each message.

This patch adds the ability to set a prefix that will be automatically applied to all log messages.