### PR TITLE
Add ability to log everything to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ A `string` to specify the log level. Defaults to `info`.
 Specify this option if you want to set a prefix for all log messages.
 This must be a `string` or a `function` that returns a string.
 
+### stderr
+
+A `boolean` to log everything to stderr. Defauls to `false`.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -21,16 +21,18 @@ module.exports = function (opts) {
       var prefix = opts.prefix
       var normalizedLevel
 
+      if (prefix) {
+        if (typeof prefix === 'function') prefix = prefix()
+        arguments[0] = util.format(prefix, arguments[0])
+      }
+
+      if (opts.stderr) return console.error.apply(console, arguments)
+
       switch (level) {
         case 'trace': normalizedLevel = 'info'; break
         case 'debug': normalizedLevel = 'info'; break
         case 'fatal': normalizedLevel = 'error'; break
         default: normalizedLevel = level
-      }
-
-      if (prefix) {
-        if (typeof prefix === 'function') prefix = prefix()
-        arguments[0] = util.format(prefix, arguments[0])
       }
 
       console[normalizedLevel].apply(console, arguments)

--- a/test.js
+++ b/test.js
@@ -80,6 +80,54 @@ test('log all', function (t) {
   t.end()
 })
 
+test('log all to stderr', function (t) {
+  var logger = Logger({ level: 'trace', stderr: true })
+
+  mock()
+  logger.trace('foo')
+  t.notOk(console.infoCalled, 'info not called')
+  t.notOk(console.warnCalled, 'warn not called')
+  t.ok(console.errorCalled, 'error called')
+  restore()
+
+  mock()
+  logger.debug('foo')
+  t.notOk(console.infoCalled, 'info not called')
+  t.notOk(console.warnCalled, 'warn not called')
+  t.ok(console.errorCalled, 'error called')
+  restore()
+
+  mock()
+  logger.info('foo')
+  t.notOk(console.infoCalled, 'info not called')
+  t.notOk(console.warnCalled, 'warn not called')
+  t.ok(console.errorCalled, 'error called')
+  restore()
+
+  mock()
+  logger.warn('foo')
+  t.notOk(console.infoCalled, 'info not called')
+  t.notOk(console.warnCalled, 'warn not called')
+  t.ok(console.errorCalled, 'error called')
+  restore()
+
+  mock()
+  logger.error('foo')
+  t.notOk(console.infoCalled, 'info not called')
+  t.notOk(console.warnCalled, 'warn not called')
+  t.ok(console.errorCalled, 'error called')
+  restore()
+
+  mock()
+  logger.fatal('foo')
+  t.notOk(console.infoCalled, 'info not called')
+  t.notOk(console.warnCalled, 'warn not called')
+  t.ok(console.errorCalled, 'error called')
+  restore()
+
+  t.end()
+})
+
 test('default level', function (t) {
   var logger = Logger()
 


### PR DESCRIPTION
This adds a `stderr` option to log everything to the standard error.
Fixes #4.
