### PR TITLE
use streams

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,8 +1,6 @@
 'use strict'
 
 var test = require('tape')
-var PassThrough = require('stream').PassThrough
-
 var Logger = require('./')
 
 function spyOn (obj, method, fn) {
@@ -15,8 +13,17 @@ function spyOff (obj, method) {
   delete obj['~' + method]
 }
 
+function createFakeStream () {
+  var queue = []
+
+  function read () { return (queue.length ? queue.shift() : null) }
+  function write (data) { queue.push(data) }
+
+  return { read: read, write: write }
+}
+
 test('log all', function (t) {
-  var stream = new PassThrough()
+  var stream = createFakeStream()
   var logger = Logger({ level: 'trace', stream: stream })
 
   logger.trace('foo')
@@ -41,7 +48,7 @@ test('log all', function (t) {
 })
 
 test('default level', function (t) {
-  var stream = new PassThrough()
+  var stream = createFakeStream()
   var logger = Logger(stream)
 
   logger.trace('foo')
@@ -57,7 +64,7 @@ test('default level', function (t) {
 })
 
 test('set custom level', function (t) {
-  var stream = new PassThrough()
+  var stream = createFakeStream()
   var logger = Logger({ level: 'warn', stream: stream })
 
   logger.info('foo')
@@ -71,7 +78,7 @@ test('set custom level', function (t) {
 
 test('set prefix', function (t) {
   var now = new Date().toISOString()
-  var stream = new PassThrough()
+  var stream = createFakeStream()
   var logger = Logger({ prefix: now, stream: stream })
   var msg = 'bar'
 
@@ -89,7 +96,7 @@ test('set prefix', function (t) {
 
 test('set prefix with function', function (t) {
   var count = 0
-  var stream = new PassThrough()
+  var stream = createFakeStream()
   var prefix = function () { return String(++count) }
   var logger = Logger({ prefix: prefix, stream: stream })
   var msg = 'bar'

--- a/test.js
+++ b/test.js
@@ -1,186 +1,97 @@
 'use strict'
 
 var test = require('tape')
+var PassThrough = require('stream').PassThrough
+
 var Logger = require('./')
 
-var origInfo = console.info
-var origWarn = console.warn
-var origError = console.error
-
-var mock = function () {
-  console.info = function () { this.infoCalled = true }
-  console.warn = function () { this.warnCalled = true }
-  console.error = function () { this.errorCalled = true }
-}
-
-var restore = function () {
-  delete console.infoCalled
-  delete console.warnCalled
-  delete console.errorCalled
-  console.info = origInfo
-  console.warn = origWarn
-  console.error = origError
-}
-
-var spyOn = function (method, spy) {
-  console['~' + method] = console[method]
-  console[method] = spy
-}
-
-var spyOff = function (method) {
-  console[method] = console['~' + method]
-  delete console['~' + method]
-}
-
 test('log all', function (t) {
-  var logger = Logger({ level: 'trace' })
+  var stream = new PassThrough()
+  var logger = Logger({ level: 'trace', stream: stream })
 
-  mock()
   logger.trace('foo')
-  t.ok(console.infoCalled, 'info called')
-  t.notOk(console.warnCalled, 'warn not called')
-  t.notOk(console.errorCalled, 'error not called')
-  restore()
+  t.equal(stream.read().toString(), 'foo\n')
 
-  mock()
   logger.debug('foo')
-  t.ok(console.infoCalled, 'info called')
-  t.notOk(console.warnCalled, 'warn not called')
-  t.notOk(console.errorCalled, 'error not called')
-  restore()
+  t.equal(stream.read().toString(), 'foo\n')
 
-  mock()
   logger.info('foo')
-  t.ok(console.infoCalled, 'info called')
-  t.notOk(console.warnCalled, 'warn not called')
-  t.notOk(console.errorCalled, 'error not called')
-  restore()
+  t.equal(stream.read().toString(), 'foo\n')
 
-  mock()
   logger.warn('foo')
-  t.notOk(console.infoCalled, 'info not called')
-  t.ok(console.warnCalled, 'warn called')
-  t.notOk(console.errorCalled, 'error not called')
-  restore()
+  t.equal(stream.read().toString(), 'foo\n')
 
-  mock()
   logger.error('foo')
-  t.notOk(console.infoCalled, 'info not called')
-  t.notOk(console.warnCalled, 'warn not called')
-  t.ok(console.errorCalled, 'error called')
-  restore()
+  t.equal(stream.read().toString(), 'foo\n')
 
-  mock()
   logger.fatal('foo')
-  t.notOk(console.infoCalled, 'info not called')
-  t.notOk(console.warnCalled, 'warn not called')
-  t.ok(console.errorCalled, 'error called')
-  restore()
+  t.equal(stream.read().toString(), 'foo\n')
 
   t.end()
 })
 
 test('default level', function (t) {
-  var logger = Logger()
+  var stream = new PassThrough()
+  var logger = Logger(stream)
 
-  mock()
   logger.trace('foo')
-  t.notOk(console.infoCalled, 'info not called')
-  t.notOk(console.warnCalled, 'warn not called')
-  t.notOk(console.errorCalled, 'error not called')
-  restore()
+  t.equal(stream.read(), null)
 
-  mock()
   logger.debug('foo')
-  t.notOk(console.infoCalled, 'info not called')
-  t.notOk(console.warnCalled, 'warn not called')
-  t.notOk(console.errorCalled, 'error not called')
-  restore()
+  t.equal(stream.read(), null)
 
-  mock()
   logger.info('foo')
-  t.ok(console.infoCalled, 'info called')
-  t.notOk(console.warnCalled, 'warn not called')
-  t.notOk(console.errorCalled, 'error not called')
-  restore()
+  t.equal(stream.read().toString(), 'foo\n')
 
   t.end()
 })
 
 test('set custom level', function (t) {
-  var logger = Logger({ level: 'warn' })
+  var stream = new PassThrough()
+  var logger = Logger({ level: 'warn', stream: stream })
 
-  mock()
   logger.info('foo')
-  t.notOk(console.infoCalled, 'info not called')
-  t.notOk(console.warnCalled, 'warn not called')
-  t.notOk(console.errorCalled, 'error not called')
-  restore()
+  t.equal(stream.read(), null)
 
-  mock()
   logger.warn('foo')
-  t.notOk(console.infoCalled, 'info not called')
-  t.ok(console.warnCalled, 'warn called')
-  t.notOk(console.errorCalled, 'error not called')
-  restore()
+  t.equal(stream.read().toString(), 'foo\n')
 
   t.end()
 })
 
 test('set prefix', function (t) {
   var now = new Date().toISOString()
-  var logger = Logger({ prefix: now })
+  var stream = new PassThrough()
+  var logger = Logger({ prefix: now, stream: stream })
   var msg = 'bar'
 
-  spyOn('info', function () {
-    spyOff('info')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
-  })
-
-  spyOn('warn', function () {
-    spyOff('warn')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
-  })
-
-  spyOn('error', function () {
-    spyOff('error')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
-    t.end()
-  })
-
   logger.info('foo %s', msg)
+  t.equal(stream.read().toString(), now + ' foo bar\n')
+
   logger.warn('foo %s', msg)
+  t.equal(stream.read().toString(), now + ' foo bar\n')
+
   logger.error('foo %s', msg)
+  t.equal(stream.read().toString(), now + ' foo bar\n')
+
+  t.end()
 })
 
 test('set prefix with function', function (t) {
-  var now = new Date().toISOString()
-  var logger = Logger({ prefix: function () { return now } })
+  var count = 0
+  var stream = new PassThrough()
+  var prefix = function () { return String(++count) }
+  var logger = Logger({ prefix: prefix, stream: stream })
   var msg = 'bar'
 
-  spyOn('info', function () {
-    spyOff('info')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
-  })
-
-  spyOn('warn', function () {
-    spyOff('warn')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
-  })
-
-  spyOn('error', function () {
-    spyOff('error')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
-    t.end()
-  })
-
   logger.info('foo %s', msg)
+  t.equal(stream.read().toString(), '1 foo bar\n')
+
   logger.warn('foo %s', msg)
+  t.equal(stream.read().toString(), '2 foo bar\n')
+
   logger.error('foo %s', msg)
+  t.equal(stream.read().toString(), '3 foo bar\n')
+
+  t.end()
 })


### PR DESCRIPTION
*fixes #4*

- Changes the default output to always be `stderr`, instead of some levels to `stdout` and some levels to `stderr`
- Allows passing in any stream for outputting to
- Simplifies the testing by using streams
- Only parse the specified log level once, instead of at every call