### PR TITLE
Run the `shouldLog` function only at initialization time

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var util = require('util')
 
 var levels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
+var noop = function () {}
 
 module.exports = function (opts) {
   opts = opts || {}
@@ -15,9 +16,9 @@ module.exports = function (opts) {
   }
 
   levels.forEach(function (level) {
-    logger[level] = function () {
-      if (!shouldLog(level)) return
+    logger[level] = shouldLog(level) ? log : noop
 
+    function log () {
       var prefix = opts.prefix
       var normalizedLevel
 


### PR DESCRIPTION
See #7.