### PR TITLE
add option to support formatted string log

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Configure the logger by passing an options object:
 ```js
 var log = require('console-log-level')({
   prefix: function () { return new Date().toISOString() },
-  level: 'info'
+  level: 'info',
+  format: true
 })
 ```
 
@@ -47,6 +48,14 @@ A `string` to specify the log level. Defaults to `info`.
 
 Specify this option if you want to set a prefix for all log messages.
 This must be a `string` or a `function` that returns a string.
+
+### format
+
+Specify this option if you want to have formatted string log.
+ex:
+```javascript
+log.info("myVar=%s myInt=%d myObject=%j", myVar, myInt, myObject);
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = function (opts) {
 
     function log () {
       var prefix = opts.prefix
+      var format = opts.format
       var normalizedLevel
 
       switch (level) {
@@ -34,7 +35,11 @@ module.exports = function (opts) {
         arguments[0] = util.format(prefix, arguments[0])
       }
 
-      console[normalizedLevel].apply(console, arguments)
+      if (format && arguments.length > 1) {
+        console[normalizedLevel](util.format.apply(null, arguments))
+      } else {
+        console[normalizedLevel].apply(console, arguments)
+      }
     }
   })
 


### PR DESCRIPTION
Specify this option if you want to have formatted string log.
ex:
```javascript
log.info("myVar=%s myInt=%d myObject=%j", myVar, myInt, myObject);
```