### PR TITLE
use util.format anywhere to support different platforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function (opts) {
         arguments[0] = util.format(prefix, arguments[0])
       }
 
-      console[normalizedLevel].apply(console, arguments)
+      console[normalizedLevel](util.format.apply(util, arguments))
     }
   })
 

--- a/test.js
+++ b/test.js
@@ -132,22 +132,19 @@ test('set prefix', function (t) {
   var logger = Logger({ prefix: now })
   var msg = 'bar'
 
-  spyOn('info', function () {
+  spyOn('info', function (arg) {
     spyOff('info')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
+    t.equal(arg, now + ' foo ' + msg, 'arg ok')
   })
 
-  spyOn('warn', function () {
+  spyOn('warn', function (arg) {
     spyOff('warn')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
+    t.equal(arg, now + ' foo ' + msg, 'arg ok')
   })
 
-  spyOn('error', function () {
+  spyOn('error', function (arg) {
     spyOff('error')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
+    t.equal(arg, now + ' foo ' + msg, 'arg ok')
     t.end()
   })
 
@@ -161,22 +158,19 @@ test('set prefix with function', function (t) {
   var logger = Logger({ prefix: function () { return now } })
   var msg = 'bar'
 
-  spyOn('info', function () {
+  spyOn('info', function (arg) {
     spyOff('info')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
+    t.equal(arg, now + ' foo ' + msg, 'arg ok')
   })
 
-  spyOn('warn', function () {
+  spyOn('warn', function (arg) {
     spyOff('warn')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
+    t.equal(arg, now + ' foo ' + msg, 'arg ok')
   })
 
-  spyOn('error', function () {
+  spyOn('error', function (arg) {
     spyOff('error')
-    t.equal(arguments[0], now + ' foo %s', 'first arg ok')
-    t.equal(arguments[1], msg, 'second arg ok')
+    t.equal(arg, now + ' foo ' + msg, 'arg ok')
     t.end()
   })
 


### PR DESCRIPTION
some platforms support [Format Specifiers](https://github.com/DeveloperToolsWG/console-object/blob/master/api.md#format-specifiers) by default like node.js
but some are not.

use util.format to parse arguments to become platform independent.

since we already import `util` as dependency, it won't break anything.
maybe add a little bit overhead if we don't use native format parser of `console`?

**rebased:** see comments in https://github.com/watson/console-log-level/pull/10/commits/bbe6c9ba88bd42e63e7470e8e11e7f1a9d540f3e