### PR TITLE
Add options to allow custom log function

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var noop = function () {}
 module.exports = function (opts) {
   opts = opts || {}
   opts.level = opts.level || 'info'
+  var logFunc = (typeof opts.logFunc === 'function' ? opts.logFunc : null)
 
   var logger = {}
 
@@ -38,7 +39,11 @@ module.exports = function (opts) {
         arguments[0] = util.format(prefix, arguments[0])
       }
 
-      console[normalizedLevel](util.format.apply(util, arguments))
+      if (logFunc) {
+        logFunc(level, util.format.apply(util, arguments))
+      } else {
+        console[normalizedLevel](util.format.apply(util, arguments))
+      }
     }
   })
 

--- a/test.js
+++ b/test.js
@@ -232,8 +232,8 @@ test('custom log function', function (t) {
   var logMessage
   var logger
 
-  logger = Logger({ 
-    logFunc: (level, message) => {
+  logger = Logger({
+    logFunc: function (level, message) {
       logLevel = level
       logMessage = message
     }
@@ -250,8 +250,8 @@ test('custom log function', function (t) {
   t.notOk(console.errorCalled, 'error not called')
   restore()
 
-  logger = Logger({ 
-    logFunc: () => {
+  logger = Logger({
+    logFunc: function () {
       console.error('hardcode error!')
     }
   })

--- a/test.js
+++ b/test.js
@@ -226,3 +226,46 @@ test('set prefix with function', function (t) {
   logger.warn('foo %s', 'bar')
   logger.error('foo %s', 'bar')
 })
+
+test('custom log function', function (t) {
+  var logLevel
+  var logMessage
+  var logger
+
+  logger = Logger({ 
+    logFunc: (level, message) => {
+      logLevel = level
+      logMessage = message
+    }
+  })
+
+  logLevel = null
+  logMessage = null
+  mock()
+  logger.warn('warn message', 'with second args!')
+  t.equal(logLevel, 'warn', 'warn level')
+  t.equal(logMessage, 'warn message with second args!', 'warn message')
+  t.notOk(console.infoCalled, 'info not called')
+  t.notOk(console.warnCalled, 'warn not called')
+  t.notOk(console.errorCalled, 'error not called')
+  restore()
+
+  logger = Logger({ 
+    logFunc: () => {
+      console.error('hardcode error!')
+    }
+  })
+
+  logLevel = null
+  logMessage = null
+  mock()
+  logger.info('info message')
+  t.equal(logLevel, null, 'log level null')
+  t.equal(logMessage, null, 'log message null')
+  t.notOk(console.infoCalled, 'info not called')
+  t.notOk(console.warnCalled, 'warn not called')
+  t.ok(console.errorCalled, 'error called')
+  restore()
+
+  t.end()
+})


### PR DESCRIPTION
I was using the library `console-log-level` to develop AWS Lambda function with log to CloudWatch. I encountered [an issue](https://stackoverflow.com/questions/43009755/does-amazon-cloudwatch-logs-support-a-newline-character) which I need to replace all `\n` characters to `\r` characters and I found no way to allow me to alter the message.

So I tried to seek other libraries such as [winston](https://www.npmjs.com/package/winston). They provide logging to different destination such as files, but they (winston) either didn't support multiple arguments supported in `console.log` or they (log4js) didn't support altering the message.

So I guess a custom log function would make things flexible here, and `console-log-level` to be used to log to file when combing with other logging libraries.

Edit 2020-02-29: Recently I found [loglevel](https://www.npmjs.com/package/loglevel) and using the plugin approach to fulfill my requirement.
Edit 2020-10-13: Recently I found winston also support multiple arguments using `format.splat()`.