### PR TITLE
Add options map between logger log level and transport log level

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ var noop = function () {}
 module.exports = function (opts) {
   opts = opts || {}
   opts.level = opts.level || 'info'
+  var levelMap = opts.levelMap || {
+    'trace': 'info',
+    'debug': 'info',
+    'fatal': 'error'
+  }
 
   var logger = {}
 
@@ -16,22 +21,19 @@ module.exports = function (opts) {
   }
 
   levels.forEach(function (level) {
-    logger[level] = shouldLog(level) ? log : noop
+    var normalizedLevel
+
+    if (opts.stderr) {
+      normalizedLevel = 'error'
+    } else {
+      normalizedLevel = level in levelMap ? levelMap[level] : level
+    }
+    if (normalizedLevel) {
+      logger[level] = shouldLog(level) ? log : noop
+    }
 
     function log () {
       var prefix = opts.prefix
-      var normalizedLevel
-
-      if (opts.stderr) {
-        normalizedLevel = 'error'
-      } else {
-        switch (level) {
-          case 'trace': normalizedLevel = 'info'; break
-          case 'debug': normalizedLevel = 'info'; break
-          case 'fatal': normalizedLevel = 'error'; break
-          default: normalizedLevel = level
-        }
-      }
 
       if (prefix) {
         if (typeof prefix === 'function') prefix = prefix(level)


### PR DESCRIPTION
Another issue I encountered when was using the library **console-log-level** to develop AWS Lambda function with log to CloudWatch is that, `console` was [monkey-patched](https://forums.aws.amazon.com/thread.jspa?threadID=238399) by AWS such that when calling `console.info`, the message output will include the word `INFO`. Unfortunately `console-log-level` mapped `require('console-log-level').debug` to `console.info`, as a result all debug message are printed with `INFO` in CloudWatch.

To allow greater control by the user, it would be good to add a mapping to map between **console-log-level** log level and transport (in this case, `console`) log level. User can also disable a log level in **console-log-level** by supplying a falsy value to avoid unintentionally called log level `fatal` which is not supported in `console`.